### PR TITLE
Enable Clair-jwt debug logs

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -46,6 +46,7 @@ COPY --from=build-env /go/bin/jwtproxy /usr/local/bin/jwtproxy
 ADD generate_mitm_ca.sh /generate_mitm_ca.sh
 ADD boot.sh /boot.sh
 ADD supervisord.conf /supervisord.conf
+ADD supervisord-debug.conf /supervisord-debug.conf
 
 VOLUME /config
 EXPOSE 6060 6061

--- a/boot.sh
+++ b/boot.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+set -e
+
+sh /generate_mitm_ca.sh
+
+if [ -z "$DEBUGLOG" ]
+then
+	echo ""
+	echo "Debugging disabled, continuing normal booting."
+	echo ""
+	exec supervisord -c /supervisord.conf
+else
+	echo ""
+	echo "Debug logs enabled."
+	echo ""
+	exec supervisord -c /supervisord-debug.conf
+fi
+

--- a/supervisord-debug.conf
+++ b/supervisord-debug.conf
@@ -1,0 +1,26 @@
+[supervisord]
+nodaemon=true
+
+[group:clairjwt]
+programs=clair,jwtproxy
+
+[program:jwtproxy]
+command=jwtproxy -config /clair/config/config.yaml
+autorestart=true
+startretries=15
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stopasgroup=true
+killasgroup=true
+
+[program:clair]
+command=clair --log-level=debug -config /clair/config/config.yaml
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stopasgroup=true
+killasgroup=true


### PR DESCRIPTION
Add `boot.sh` needed for all images that will, based on the value of `DEBUGLOG` parameter when starting the container, enable Clair debugging. 
