### PR TITLE
resolves 'sub-mgr remove --all' error

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -49,12 +49,14 @@ ADD clair-entrypoint.sh $CLAIRDIR/clair-entrypoint.sh
 ADD supervisord.conf $CLAIRDIR/supervisord.conf
 
 # Cleanup
-RUN yum clean all && \
-    rm -rf /etc/pki/entitlement /etc/rhsm && \
-    rm -rf /var/cache/yum /tmp/* /var/tmp/* /root/.cache
+RUN yum clean all
 
 # Remove subscription key
 RUN subscription-manager remove --all
+
+# Cleanup
+RUN rm -rf /etc/pki/entitlement /etc/rhsm && \
+    rm -rf /var/cache/yum /tmp/* /var/tmp/* /root/.cache
 
 RUN chgrp -R 0 $CLAIRDIR && \
     chmod -R g=u $CLAIRDIR


### PR DESCRIPTION
A change in rhel-7.6 base image packages introduced an issue with how the image cleanup needs to be handled. Without this change, the `subscription-manager remove --all` command will fail with:
```
IOError: [Errno 2] No such file or directory: '/etc/rhsm/syspurpose/syspurpose.json'
```