### PR TITLE
Update Golang version variables and Centos 7 Dockerfile

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -18,10 +18,21 @@ FROM ${REPO_NAME}:${GIT_TAG}-centos7-build-env AS build-env
 FROM centos:7
 LABEL maintainer "Sida Chen <sidchen@redhat.com>"
 
+
+# Envionrment variables
+ENV CLAIRDIR /clair
+ENV CLAIRCONF /clair/config
+
+# Set up directories
+RUN mkdir $CLAIRDIR
+WORKDIR $CLAIRDIR
+
+
 # Install init system and Clair depended binaries
 RUN yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False python-setuptools git rpm xz
 RUN rpm --version | grep -q 'version 4' # ensure rpm is version 4
 RUN easy_install supervisor
+
 
 # Copy built binaries into the runtime image
 COPY --from=build-env /go/bin/cfssl /usr/local/bin/cfssl
@@ -30,12 +41,15 @@ COPY --from=build-env /go/bin/jwtproxy /usr/local/bin/jwtproxy
 COPY --from=build-env /go/bin/clair /usr/local/bin/clair
 
 # Add the init scripts
-ADD generate_mitm_ca.rhel.sh /generate_mitm_ca.sh
-ADD boot.sh /boot.sh
-ADD supervisord.conf /supervisord.conf
+ADD generate_mitm_ca.rhel.sh $CLAIRDIR/generate_mitm_ca.sh
+ADD clair-entrypoint.sh $CLAIRDIR/clair-entrypoint.sh
+ADD supervisord.conf $CLAIRDIR/supervisord.conf
 
-VOLUME /config
-VOLUME /certs
+VOLUME /clair/config
+VOLUME /clair/certs
 EXPOSE 6060 6061
 
-CMD ["sh", "/boot.sh"]
+ENTRYPOINT ["/clair/clair-entrypoint.sh"]
+CMD ["scanner"]
+
+

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -18,21 +18,14 @@ FROM ${REPO_NAME}:${GIT_TAG}-centos7-build-env AS build-env
 FROM centos:7
 LABEL maintainer "Sida Chen <sidchen@redhat.com>"
 
-
-# Envionrment variables
 ENV CLAIRDIR /clair
 ENV CLAIRCONF /clair/config
-
-# Set up directories
-RUN mkdir $CLAIRDIR
 WORKDIR $CLAIRDIR
-
 
 # Install init system and Clair depended binaries
 RUN yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False python-setuptools git rpm xz
 RUN rpm --version | grep -q 'version 4' # ensure rpm is version 4
 RUN easy_install supervisor
-
 
 # Copy built binaries into the runtime image
 COPY --from=build-env /go/bin/cfssl /usr/local/bin/cfssl
@@ -51,5 +44,3 @@ EXPOSE 6060 6061
 
 ENTRYPOINT ["/clair/clair-entrypoint.sh"]
 CMD ["scanner"]
-
-

--- a/Dockerfile.centos7-build-env
+++ b/Dockerfile.centos7-build-env
@@ -19,11 +19,11 @@ ARG GIT_TAG
 RUN test -n "$GIT_TAG" # Expect Clair GIT TAG to be non-empty.
 
 # Install Golang by retrieving the binary
-ENV GO_VERSION=1.11.5
+ENV GO_VERSION=1.13.3
 ENV GO_OS=linux
 ENV GO_ARC=amd64
 RUN curl https://dl.google.com/go/go${GO_VERSION}.${GO_OS}-${GO_ARC}.tar.gz --output go.tar.gz
-RUN echo ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25 go.tar.gz > GOCHECKSUM
+RUN echo 0804bf02020dceaa8a7d7275ee79f7a142f1996bfd0c39216ccb405f93f994c0 go.tar.gz > GOCHECKSUM
 RUN sha256sum -c GOCHECKSUM
 RUN tar -C /usr/local -xzf go.tar.gz > /dev/null
 ENV GOPATH=/go
@@ -35,7 +35,7 @@ RUN go version
 # Install dependencies
 RUN yum install -y --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False git hg svn bzr gcc
 
-ENV CFSSL_VERSION=1.3.2
+ENV CFSSL_VERSION=1.3.4
 RUN go get -u github.com/cloudflare/cfssl/cmd/cfssl
 WORKDIR /go/src/github.com/cloudflare/cfssl
 RUN git checkout ${CFSSL_VERSION}

--- a/Dockerfile.centos7-build-env
+++ b/Dockerfile.centos7-build-env
@@ -45,7 +45,7 @@ RUN go install github.com/cloudflare/cfssl/cmd/cfssljson
 RUN go get -u github.com/coreos/jwtproxy/cmd/jwtproxy
 
 # Build Clair with git tag
-RUN go get -u -d github.com/coreos/clair/cmd/clair
+RUN git clone https://github.com/coreos/clair.git /go/src/github.com/coreos/clair
 WORKDIR /go/src/github.com/coreos/clair
 RUN git checkout $GIT_TAG
 RUN go install github.com/coreos/clair/cmd/clair

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ centos7-build-env: Dockerfile.centos7-build-env
 	echo "Building Clair build environment with tag: '${REPO_NAME}:${GIT_TAG}-centos7-build-env'"
 	docker build -f Dockerfile.centos7-build-env -t ${REPO_NAME}:${GIT_TAG}-centos7-build-env . --build-arg GIT_TAG=${GIT_TAG}
 
-centos7: Dockerfile.centos7
+centos7: centos7-build-env Dockerfile.centos7
 	echo "Building CentOS based image with tag: '${REPO_NAME}:${GIT_TAG}-centos7'"
 	docker build -f Dockerfile.centos7 -t ${REPO_NAME}:${GIT_TAG}-centos7 . --build-arg GIT_TAG=${GIT_TAG} --build-arg REPO_NAME=${REPO_NAME}
 


### PR DESCRIPTION
The old build-env Dockerfile had a Golang 1.11.5 dependancy which was incompatible with the new version of `cfssl`. This PR updates the Golang version to 1.13.2 and also changes the Centos 7 Docker files to be more similar to the RHEL one.